### PR TITLE
Build mwsoft libs with nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, x11, fontconfig, fontadobe75dpi, fontadobe100dpi, python }:
+
+stdenv.mkDerivation rec {
+  name = "mwsoft64";
+  src = ./.;
+  buildInputs = [ x11 fontadobe75dpi fontadobe100dpi fontconfig python ];
+
+  postPatch = ''
+    substituteInPlace definitions.mk --replace "/bin/date" "echo Thu Jan 1 00:00:00 UTC 1970"
+  '';
+
+  # TODO: create pkg-config files for shared libs
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./build/bin/* $out/bin/
+  '';
+  
+
+  doCheck = true;
+  meta = {
+    description = "Spike analysis utilities";
+    longDescription = ''
+      Libraries and tools developed in MIT's Wilson Lab for
+      analyzing multichannel electrode data
+    '';
+    homepage = https://github.com/wilsonlab/mwsoft64;
+    license = stdenv.lib.licenses.bsd3;
+    platforms = stdenv.lib.platforms.all;
+  };
+
+
+
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,1 @@
+(import <nixpkgs> {}).callPackage ./. {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.callPackages ./default.nix {}


### PR DESCRIPTION
The only path to avoiding all the manual tweaks needed for doing a fresh build..

See https://nixos.org/nix